### PR TITLE
Adds SpectralElementTransform

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,8 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterTools = "35a29f4d-8980-5a13-9543-d66fff28ecb8"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
+GaussQuadrature = "d54b0c1a-921d-58e0-8e36-89d8069c0969"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Tullio = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 

--- a/src/OperatorFlux.jl
+++ b/src/OperatorFlux.jl
@@ -3,6 +3,7 @@ module OperatorFlux
 using Flux
 using FFTW
 using GaussQuadrature
+using LinearAlgebra
 using Tullio
 using ChainRulesCore
 
@@ -61,6 +62,7 @@ pad_modes(trafo::AbstractTransform, _...) =
 include("utils.jl")
 include("fourier.jl")
 include("chebyshev.jl")
+include("legendre.jl")
 include("operators.jl")
 
 end # module

--- a/src/OperatorFlux.jl
+++ b/src/OperatorFlux.jl
@@ -2,6 +2,7 @@ module OperatorFlux
 
 using Flux
 using FFTW
+using GaussQuadrature
 using Tullio
 using ChainRulesCore
 

--- a/src/legendre.jl
+++ b/src/legendre.jl
@@ -1,0 +1,81 @@
+struct LegendreTransform{N,T,D} <: AbstractTransform
+    modes::NTuple{N,T}
+    dims::D
+end
+
+function LegendreTransform(; modes::NTuple{N,T}) where {N,T}
+    # assumes transform is over first consecutive space-like
+    # dimensions, aka 2:N+1
+    dims = 2:(length(modes)+1)
+    return LegendreTransform(modes, dims)
+end
+
+function forward(tr::LegendreTransform{N}, x, dims = tr.dims) where {N}
+    return fft(x, dims)
+end
+
+function inverse(tr::LegendreTransform{N}, x, dims = tr.dims) where {N}
+    return ifft(x, dims)
+end
+
+# function truncate_modes(tr::LegendreTransform{N}, c, dims = tr.dims) where {N}
+#     # return a low-pass filtered version of c assuming
+#     # that c is a tensor of spectral weights.
+#     # Want to keep 1:M+1 to end-M+2:end using FFTW convention
+#     #
+#     # Ex.: tr.modes = (2,)
+#     # [0, 1, 2, 3, -2, -1] -> [0, 1, 2, -1]
+#     # [a, b, c, d,  e,  f] -> [a, b, c,  f]
+
+#     # calculate the retained modes taking into account the dimensions
+#     # that the spectral transform operates over
+#     size_space = size(c)[2:end-1] # sizes of space-like dimensions of c
+#     inds_space = 2:length(size_space)+1 # indices of space-like dimensions of c
+#     inds_map = Dict(zip(dims, tr.modes)) # maps index location to retained modes
+#     inds_offset = 1
+
+#     # we only truncate along dimensions contained in dims and otherwise keep
+#     # all modes
+#     modes = [i ∈ dims ? inds_map[i] : div(size_space[i-inds_offset], 2) for i in inds_space]
+
+#     # indices for the spectral coefficients that we need to retain
+#     inds = [vcat(collect(1:m+1), collect(s-m+2:s)) for (s, m) in zip(size(c)[2:end-1], modes)]
+#     c_truncated = OperatorFlux.mview(c, inds, Val(length(size_space)))
+
+#     return c_truncated
+# end
+
+# function pad_modes(::LegendreTransform, c, size_pad::NTuple)
+#     # return a padded-with-zeros version of c assuming
+#     # that c is a tensor of spectral weights, thereby inflating c.
+#     # Want to keep 1:M+1 to end-M+2:end using FFTW convention, so need to 
+#     # fill rest with zeros.
+#     #
+#     # Ex.: dims = (6,)
+#     # [0, 1, 2, -1] -> [0, 1, 2, 3, -2, -1]
+#     # [a, b, c,  d] -> [a, b, c, 0,  0,  d]
+#     N = length(size_pad) # number of space-like dimensions
+#     c_padded = zeros(eltype(c), (size(c)[1], size_pad..., size(c)[end]))
+#     inds = [vcat(collect(1:div(m, 2)+1), collect(s-div(m, 2)+2:s)) for (s, m) in zip(size_pad, size(c)[2:end-1])]
+#     c_padded_view = OperatorFlux.mview(c_padded, inds, Val(N))
+#     c_padded_view .= c
+
+#     return c_padded
+# end
+
+# utils
+function vandermonde(x, α, β, N)
+
+end
+
+# Base extensions
+Base.ndims(::LegendreTransform{N}) where {N} = N
+Base.eltype(::LegendreTransform) = Float32
+Base.size(tr::LegendreTransform) = tr.modes
+
+function Base.show(io::IO, tr::LegendreTransform)
+    print(
+        io,
+        "LegendreTransform(modes = $(tr.modes)"
+    )
+end

--- a/test/legendre.jl
+++ b/test/legendre.jl
@@ -2,13 +2,23 @@ using OperatorFlux
 using Test
 using FFTW
 using Flux
+using GaussQuadrature
 using LinearAlgebra
 using Revise
 using ChainRulesCore
 using ChainRulesTestUtils
 
+import OperatorFlux: legendre_transform_forward_matrix, legendre_transform_inverse_matrix
+
 @testset "LegendreTransform" begin
     # auxiliary data
+    P₀(x) = 1
+    P₁(x) = x
+    P₂(x) = 0.5 * (3 * x^2 - 1)
+    P₃(x) = 0.5 * (5 * x^3 - 3 * x)
+    P₄(x) = 0.125 * (35 * x^4 - 30 * x^2 + 3)
+    P₅(x) = 0.125 * (63 * x^5 - 70 * x^3 + 15 * x)
+    polynomials = [P₀, P₁, P₂, P₃, P₄, P₅]
 
     # test constructors
 
@@ -20,6 +30,32 @@ using ChainRulesTestUtils
 
     # rountrip integration test
 
-    # test Base extensions
+    # test utils
+    for n in 6:16
+        x, _ = GaussQuadrature.legendre(n, GaussQuadrature.both)
 
+        inv_transform = legendre_transform_inverse_matrix(n)
+        transform = inv(inv_transform)
+        @test all(transform .== legendre_transform_forward_matrix(n))
+    
+        for (i, p) in enumerate(polynomials)
+            @test (transform*p.(x))[i] - 1 ≤ eps(10*norm(p.(x)))
+            @test norm(transform * p.(x)) - 1 ≤ eps(10*norm(p.(x)))
+        end
+        for (i, p) in enumerate(polynomials)
+            @test norm(inv_transform * transform * p.(x) - p.(x)) ≤ eps(10 * norm(p.(x)))
+        end
+    end
+
+    # test Base extensions
+    # trafo = LegendreTransform()
+    # @test ndims(trafo) == 
+    # @test eltype(trafo) == Float32
+    # @test size(trafo) == 
 end
+
+#=
+LTM = legendretransformmatrix 
+
+@tullio q[s, i, j, k, e, b] := LTM[i,ii] * LTM[j, jj] * LTM[k, kk] * q[s, ii, jj, kk, e, b]
+=#

--- a/test/legendre.jl
+++ b/test/legendre.jl
@@ -1,0 +1,25 @@
+using OperatorFlux
+using Test
+using FFTW
+using Flux
+using LinearAlgebra
+using Revise
+using ChainRulesCore
+using ChainRulesTestUtils
+
+@testset "LegendreTransform" begin
+    # auxiliary data
+
+    # test constructors
+
+    # test forward & inverse
+
+    # test truncate_modes
+
+    # test pad_modes
+
+    # rountrip integration test
+
+    # test Base extensions
+
+end


### PR DESCRIPTION
This PR adds a spectral element transform that will work for general geometries that can be efficiently paramterized using spectral elements. This is useful for emulators on bumpy spheres and for mountain situations in LES. It will also enable a few other interesting tricks for ocean parameterizations.

- [x] implement Legendre transform & its utils
- [ ] implement SpectralElementGrid
- [ ] add tests

