### PR TITLE
feat: add CLA workflow caller

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,20 @@
+---
+name: CLA Workflow
+
+permissions:
+  contents: write
+  checks: write
+  actions: write
+  pull-requests: write
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - staging
+      - main
+
+jobs:
+  cla:
+    uses: ec-intl/workflow-templates/.github/workflows/cla_template.yml@main
+    secrets: inherit

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -8,6 +8,7 @@ permissions:
   pull-requests: write
 
 on:
+  merge_group:
   pull_request:
     types: [opened, reopened, synchronize]
     branches:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -11,10 +11,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
     branches:
-      - staging
       - main
+      - master
 
 jobs:
   cla:
-    uses: ec-intl/workflow-templates/.github/workflows/cla_template.yml@main
+    uses: clima/.github/.github/workflows/cla_template.yml@main
     secrets: inherit


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR introduces an automated Contributor License Agreement (CLA) check. External contributors must agree to the CLA once via a lightweight GitHub-authenticated flow before their PRs can be merged. The check runs automatically on pull requests and blocks the merge only if a required CLA is missing.

CLA text: https://ecodesign.clima.caltech.edu/cla/download/

How to sign: authenticate with GitHub, type your name, and click the “I agree” button.

(Caltech, MIT, JPL Employees and automated bots are not affected.)

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->
- [x] Add the CLA workflow caller

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Added `.github/workflows/cla.yml` using the organization template.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
