### PR TITLE
fix: trigger CLA on bot PR review and auto-merge events

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -10,7 +10,7 @@ permissions:
 on:
   merge_group:
   pull_request_target:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, auto_merge_enabled, review_requested]
     branches:
       - main
       - master


### PR DESCRIPTION
## Purpose

Closes #49.

This PR updates the CLA workflow triggers so the CLA check can run during the review and auto-merge flow for bot-created pull requests.

## To-do

* None.

## Content

* Updated `.github/workflows/cla.yml` to include `review_requested` and `auto_merge_enabled` in the `pull_request_target` event types.
* Preserved the existing CLA triggers for `opened`, `reopened`, `synchronize`, and `merge_group`.
* Expanded the workflow trigger coverage without changing the CLA validation logic itself.

---

* [x] I have read and checked the items on the review checklist.
